### PR TITLE
Fix issue between PySide5 and PySide6

### DIFF
--- a/btl/ui/feedsandspeeds.py
+++ b/btl/ui/feedsandspeeds.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from PySide.QtCore import Qt, QObject, QEvent
 from PySide.QtGui import QApplication
-from PySide import QtGui, QtCore
+from PySide import QtGui, QtCore, __version__ as pyside_version
 from ..i18n import translate
 from ..machine import Machine
 from ..feeds import FeedCalc
@@ -12,6 +12,7 @@ from ..units import convert
 from .util import load_ui
 from .spinbox import DistanceSpinBox
 from .machineeditor import MachineEditor
+from pip._internal.metadata import pkg_resources
 
 __dir__ = os.path.dirname(__file__)
 ui_path = os.path.join(__dir__, "feedsandspeeds.ui")
@@ -302,7 +303,10 @@ class FeedsAndSpeedsWidget(QtGui.QWidget):
         params = sorted(params.items(), key=lambda x: x[0].lower())
         font = QtGui.QFont()
         font.setBold(True)
-        font.setWeight(75)
+        if pkg_resources.parse_version(pyside_version) >= pkg_resources.parse_version("6.0.0"):  # PySide6
+            font.setWeight(QtGui.QFont.Weight.Bold)
+        else: # PySide5
+            font.setWeight(75)
         for row, (name, param) in enumerate(params):
             # First column: Name.
             label = name.replace('_', ' ').title()

--- a/btl/ui/toolproperties.py
+++ b/btl/ui/toolproperties.py
@@ -1,5 +1,7 @@
 from functools import partial
-from PySide import QtGui, QtSvg, QtCore
+from PySide import QtGui, QtSvg, QtCore, __version__ as pyside_version
+from pip._internal.metadata import pkg_resources
+
 from ..shape import get_property_label_from_name
 from ..i18n import translate
 from ..params import DistanceParam
@@ -116,7 +118,12 @@ class ToolProperties(PropertyWidget):
         label = QtGui.QLabel(lbl)
         self.grid.addWidget(label, row, 0)
         label = QtGui.QLabel(tool.id)
-        label.setTextInteractionFlags(QtGui.Qt.TextSelectableByKeyboard \
+        if pkg_resources.parse_version(pyside_version) >= pkg_resources.parse_version("6.0.0"):  # PySide6
+            label.setTextInteractionFlags(QtCore.Qt.TextSelectableByKeyboard \
+                                         |QtCore.Qt.TextSelectableByMouse)
+            label.setFocusPolicy(QtCore.Qt.StrongFocus)
+        else:  # PySide5
+            label.setTextInteractionFlags(QtGui.Qt.TextSelectableByKeyboard \
                                      |QtGui.Qt.TextSelectableByMouse \
                                      |QtGui.Qt.StrongFocus)
         self.grid.addWidget(label, row, 1)


### PR DESCRIPTION
Updated PySide API usage to support PySide6  

This merge includes changes to the codebase to ensure compatibility with PySide6, the latest version of the PySide library. The updates primarily involve modifying the arguments passed to certain methods and handling the differences in the way certain features are implemented in PySide6 compared to PySide5.  Key changes include:  

1. Updating the setTextInteractionFlags and setFocusPolicy methods in toolproperties.py to handle the different enumerations in PySide6.
2. Modifying the setWeight method in feedsandspeeds.py to use the QFont.Weight enumeration in PySide6.
3. Adjusting the load_ui and qpixmap_from_svg methods in util.py to handle the different ways of working with directories and buffers in PySide6.


These changes ensure that the application remains functional and up-to-date with the latest PySide API, while still maintaining backward compatibility with PySide5.