### PR TITLE
Amend setup instructions to include library creation

### DIFF
--- a/docs/feeds-and-speeds.md
+++ b/docs/feeds-and-speeds.md
@@ -70,7 +70,8 @@ Before using the Feeds & Speeds calculator, you have to let BTL know your machin
 This is done as follows:
 
 - Open BTL by clicking the icon in the task bar:
-  ![Toolbar](media/toolbar.png)
+
+![Toolbar](../media/toolbar.png)
  
 - If not done already, create a library (File -> Create Library) and your tool bit first (File -> Create Tool)
 - Once the tool is created, open the tool editor by double-clicking on the tool in the BTL main window.

--- a/docs/feeds-and-speeds.md
+++ b/docs/feeds-and-speeds.md
@@ -69,8 +69,10 @@ It takes into account a dozen of factors:
 Before using the Feeds & Speeds calculator, you have to let BTL know your machine parameters.
 This is done as follows:
 
-- Open BTL by clicking the icon in the task bar.
-- If not done already, create your tool bit first (File -> Create Tool)
+- Open BTL by clicking the icon in the task bar:
+  ![Toolbar](media/toolbar.png)
+ 
+- If not done already, create a library (File -> Create Library) and your tool bit first (File -> Create Tool)
 - Once the tool is created, open the tool editor by double-clicking on the tool in the BTL main window.
 - Switch to the "Feeds & Speeds" tab.
 - At the top, press "+" to create your machine.


### PR DESCRIPTION
* Include visual reference to task bar icon
* Add instructions to create a library file before creating a tool (otherwise FreeCAD closes the dialog with an error referencing the `get_next_tool_no` function)

Just a couple bits of documentation that would've helped me in setting up this great addon :)