### PR TITLE
fix: typos in source comments and docs

### DIFF
--- a/btl/feeds/calc.py
+++ b/btl/feeds/calc.py
@@ -328,7 +328,7 @@ class FeedCalc(object):
 
           (error_distance, error, params)
 
-        - error (str): An error message, if the result is invalid. None otherwse.
+        - error (str): An error message, if the result is invalid. None otherwise.
         - params (dict): The list of params, as stored in .all_params.
         """
         random.seed(1) # we don't want true randomness, rather reproducible results

--- a/btl/serializers/fcserializer.py
+++ b/btl/serializers/fcserializer.py
@@ -347,7 +347,7 @@ class FCSerializer(Serializer):
         tool = Tool(attrs['name'], shape, id=id, filename=filename)
 
         # Load known attributes. Since the serialized file does not indicate
-        # param types, we need to explicitely load known non-str attributes.
+        # param types, we need to explicitly load known non-str attributes.
         tool_attrs = attrs.get("attribute", {})
         stickout = tool_attrs.pop('btl-stickout', None)
         if stickout:

--- a/btl/serializers/fusionserializer.py
+++ b/btl/serializers/fusionserializer.py
@@ -26,7 +26,7 @@ MATERIAL_MAP = {
 #  I.E.: chamfer mills & spot_drills
 # Custom form tools, thread mills, and taps are not supported yet
 # (thread mills can be single or multi-pitch, we would need to generate the
-# shape files at runtime in order to suppport them properly)
+# shape files at runtime in order to support them properly)
 SHAPE_FILES = {
     # milling
     "ball end mill": "ball_end_mill",

--- a/btl/tool.py
+++ b/btl/tool.py
@@ -297,7 +297,7 @@ class Tool(object):
         diameter = self.shape.get_diameter()
         fluted_inertia = (math.pi * ((diameter*0.8) / 2)**4) / 4
 
-        # Moment of inertia equation for a SOLID round beam (shank partion of the end mill)
+        # Moment of inertia equation for a SOLID round beam (shank portion of the end mill)
         # https://en.wikipedia.org/wiki/List_of_area_moments_of_inertia
         shank_d = self.shape.get_shank_diameter()
         if shank_d:


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.ts"`