### PR TITLE
Update subdirectory in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
   <content>
     <workbench>
       <classname>BetterToolLibrary</classname>
-      <subdirectory>./</subdirectory>
+      <subdirectory>btl</subdirectory>
       <icon>resources/icons/tool-library.svg</icon>
       <freecadmin>0.19.0</freecadmin>
     </workbench>


### PR DESCRIPTION
The Addon Manager cannot find the icon for the BTL because the subdirectory is not set right.