### PR TITLE
better-tool-library: update icon path in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -2,6 +2,7 @@
 <package format="1">
   <name>Better Tool Library</name>
   <description>A FreeCAD Path Addon to manage your tool library.</description>
+  <icon>btl/resources/icons/tool-library.svg</icon>
   <version>0.9.9</version>
   <maintainer email="knipknap@gmail.com">Samuel Abels</maintainer>
   <license file="LICENSE">MIT</license>
@@ -12,7 +13,6 @@
     <workbench>
       <classname>BetterToolLibrary</classname>
       <subdirectory>./</subdirectory>
-      <icon>resources/icons/tool-library.svg</icon>
       <freecadmin>0.19.0</freecadmin>
     </workbench>
   </content>


### PR DESCRIPTION
Fix `<icon>` path so it matches [the icon resource](https://github.com/knipknap/better-tool-library/blob/main/btl/resources/icons/tool-library.svg).

Although BTL has been integrated into FreeCAD core and is deprecated in the future, adjusting the metadata still seems appropriate.